### PR TITLE
Improve Pts responsiveness

### DIFF
--- a/scripts/canvas.js
+++ b/scripts/canvas.js
@@ -1,15 +1,29 @@
 'use strict';
 
-window.addEventListener('resize', () => {
-  space.removeAll();
-  document.getElementById('pt_canvas').remove();
-  Pts.quickStart( '#pt', 'transparent' );
-  animatePts();
-}, true);
+let windowWidth = window.innerWidth;
 
-Pts.quickStart( '#pt', 'transparent' );
+function restartPts(){
+  // We only want to restart Pts if the width changes
+  if (window.innerWidth === windowWidth) {
+    return;
+  } else {
+    windowWidth = window.innerWidth;
+    space.removeAll();
+    document.getElementById('pt_canvas').remove();
+    animatePts();
+  }
+}
+
+let resizeTimeout;
+window.onresize = function(){
+  // Timeout to avoid triggering restarts for every resize event
+  clearTimeout(resizeTimeout);
+  resizeTimeout = setTimeout(restartPts, 500);
+};
 
 function animatePts() {
+  Pts.quickStart( '#pt', 'transparent' );
+
   let pts = new Group();
 
   space.add({ 


### PR DESCRIPTION
Improve responsiveness of Pts animation:
- Only trigger a restart when window width changes (prevents unnecessary restarts when window height changes while scrolling on iPhone).
- Wait 0.5 seconds after last resize event before triggering a restart (prevents multiple restarts for multiple consecutive resize events).